### PR TITLE
fix: export version from cmd to fang

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,7 +42,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X github.com/mcornick/clilol/cmd.version={{.Version}}
+      - -s -w -X github.com/mcornick/clilol/cmd.Version={{.Version}}
     mod_timestamp: "{{ .CommitTimestamp }}"
     targets:
       - go_first_class

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,9 +27,9 @@ const endpoint = "https://api.omg.lol"
 
 var (
 	addressFlag string
-	version     = "dev"
+	Version     = "dev"
 	RootCmd     = &cobra.Command{
-		Version: version,
+		Version: Version,
 		Use:     "clilol",
 		Short:   "a CLI for omg.lol",
 		Long: `This is clilol, a CLI for omg.lol.
@@ -105,7 +105,7 @@ func callAPI(method string, path string, bodyReader io.Reader, auth bool) ([]byt
 	if err != nil {
 		return nil, err
 	}
-	request.Header.Set("User-Agent", "clilol/"+version+" (https://clilol.readthedocs.io)")
+	request.Header.Set("User-Agent", "clilol/"+Version+" (https://clilol.readthedocs.io)")
 	request.Header.Set("Content-Type", "application/json")
 	if auth {
 		request.Header.Set("Authorization", "Bearer "+viper.GetString("apikey"))

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 func main() {
-	err := fang.Execute(context.TODO(), cmd.RootCmd)
+	err := fang.Execute(context.TODO(), cmd.RootCmd, fang.WithVersion(cmd.Version))
 	if err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
Fixes fang reporting an unknown version. GoReleaser sets the version via ldflags on a release; otherwise, the version is "dev."

Closes #89.