### PR TITLE
explicitly check $XDG_CONFIG_HOME/clilol

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,6 +59,10 @@ func loadConfig() error {
 	viper.SetConfigName("config")
 	viper.AddConfigPath("/etc/clilol/")
 	viper.AddConfigPath(configDir + "/clilol")
+	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfigHome != "" {
+		viper.AddConfigPath(xdgConfigHome + "/clilol")
+	}
 	viper.SetEnvPrefix("clilol")
 	viper.SetDefault("address", "")
 	viper.SetDefault("apikey", "")

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,8 +105,8 @@ clilol expects a configuration file to specify your address, login email, and AP
 
 The configuration file should be named either `config.yaml`, `config.toml` or `config.json` depending on which format you prefer, and should be located in one of these directories:
 
-- `$HOME/Library/Application Support/clilol` (macOS)
-- `$XDG_CONFIG_HOME/clilol` (Unix)
+- `$HOME/Library/Application Support/clilol` (macOS default)
+- `$XDG_CONFIG_HOME/clilol` (Unix; also checked on macOS if `$XDG_CONFIG_HOME` is set)
 - `/etc/clilol` (macOS or Unix)
 - `%AppData%\clilol` (Windows)
 


### PR DESCRIPTION
- **fix: explicitly check $XDG_CONFIG_HOME/clilol**
- **docs: $XDG_CONFIG_HOME is now supported on macOS**
